### PR TITLE
Add Mongo-based allowlist and access commands

### DIFF
--- a/db.py
+++ b/db.py
@@ -10,8 +10,23 @@ db = _client[MONGO_DB]
 
 reminders = db["reminders"]
 notes = db["notes"]
+access = db["access"]  # хранит списки доступа, например {_id:"allowed", ids:[...int...]}
 
 async def ensure_indexes():
     await reminders.create_index([("when", 1)])
     await reminders.create_index("id", unique=True, sparse=True)
     await notes.create_index([("user_id", 1), ("created_at", -1)])
+    # для access достаточно _id по умолчанию
+
+# ===== Utilities for access control =====
+async def get_allowed_set() -> set[int]:
+    doc = await access.find_one({"_id": "allowed"})
+    if not doc:
+        return set()
+    return {int(x) for x in doc.get("ids", [])}
+
+async def add_allowed(uid: int) -> None:
+    await access.update_one({"_id": "allowed"}, {"$addToSet": {"ids": int(uid)}}, upsert=True)
+
+async def remove_allowed(uid: int) -> None:
+    await access.update_one({"_id": "allowed"}, {"$pull": {"ids": int(uid)}}, upsert=True)

--- a/webhook.py
+++ b/webhook.py
@@ -5,7 +5,7 @@ from aiohttp import web
 from aiogram import Bot, Dispatcher
 from aiogram.webhook.aiohttp_server import SimpleRequestHandler, setup_application
 
-from Postavka import bot as main_bot, dp as main_dp, setup_handlers
+from Postavka import bot as main_bot, dp as main_dp, setup_handlers, refresh_access_cache
 from db import ensure_indexes
 from reminders import process_due_reminders
 
@@ -33,6 +33,7 @@ setup_handlers()
 
 async def on_startup(app: web.Application):
     await ensure_indexes()
+    await refresh_access_cache()  # 🔑 подтянем allowlist из Mongo
     url = BASE_URL.rstrip("/") + WEBHOOK_PATH
     await bot.set_webhook(url, secret_token=WEBHOOK_SECRET, drop_pending_updates=False)
     log.info("Webhook set to %s", url)


### PR DESCRIPTION
## Summary
- track dynamic allowlist in MongoDB
- add admin commands to manage allowlist
- broadcast reminders to allowlist users and expose /tz command
- refresh allowlist on webhook startup

## Testing
- `python -m py_compile db.py Postavka.py reminders.py webhook.py`


------
https://chatgpt.com/codex/tasks/task_e_68aafcb0479c832b9cfe5d49435c788c